### PR TITLE
Save configuration files in user directory

### DIFF
--- a/86BoxManager.Core/Registry/Configs.cs
+++ b/86BoxManager.Core/Registry/Configs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text;
 using Newtonsoft.Json;
@@ -18,11 +19,13 @@ namespace _86BoxManager.Registry
             {
                 Formatting = Formatting.Indented
             };
-            var ass = typeof(Configs).Assembly;
-            var loc = IOPath.GetFullPath(ass.Location);
-            var dir = IOPath.GetDirectoryName(loc) ?? string.Empty;
-            BoxConfigName = IOPath.Combine(dir, "86Box.json");
-            VmxConfigName = IOPath.Combine(dir, "86BoxVMs.json");
+
+            var userConfigDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.Create);
+            var appConfigDir = IOPath.Combine(userConfigDir, "86BoxManager");
+            if (!Directory.Exists(appConfigDir)) Directory.CreateDirectory(appConfigDir);
+
+            BoxConfigName = IOPath.Combine(appConfigDir, "86Box.json");
+            VmxConfigName = IOPath.Combine(appConfigDir, "86BoxVMs.json");
         }
 
         private static void WriteJson(string fileName, object obj)


### PR DESCRIPTION
This PR changes location where configuration files are saved and loaded from. Thanks to build-in `SpecialFolder.ApplicationData` enum the config directory is correctly guessed depends of environment so e.g. on Linux it will be `~/.config` and on Windows `%AppData%`.

Using configuration files in assembly location prevents usage per-user configuration and makes packaging for distributions harder.

I've created Arch Linux packages in AUR ([1](https://aur.archlinux.org/packages/86box-manager), [2](https://aur.archlinux.org/packages/86box-manager-bin), [3](https://aur.archlinux.org/packages/86box-manager-git)) and currently the configuration is kept with program files in `/opt/86BoxManager` which is a bad practice.